### PR TITLE
Allowing Websocket Client to attempt reconnect.

### DIFF
--- a/src/WebSocketClient.cpp
+++ b/src/WebSocketClient.cpp
@@ -68,6 +68,9 @@ WebSocketClient::~WebSocketClient()
 void WebSocketClient::connect( const std::string& uri )
 {
 	try {
+		if (mClient.stopped()){
+			mClient.reset();
+		}
 		websocketpp::lib::error_code err;
 		Client::connection_ptr conn = mClient.get_connection( uri, err );
 		if ( err ) {


### PR DESCRIPTION
After connection closed/failed, it is necessary
to call reset() on the underlying websocketPP
client. Now this is done automatically when
attempting to connect() again.
