### PR TITLE
Exposing a method for sending binary data.

### DIFF
--- a/src/WebSocketServer.cpp
+++ b/src/WebSocketServer.cpp
@@ -129,6 +129,31 @@ void WebSocketServer::run()
 	mServer.run();
 }
 
+void WebSocketServer::write( void const * msg, size_t len )
+{
+	if (len == 0){
+		if ( mFailEventHandler != nullptr ) {
+			mFailEventHandler( "Cannot send empty message." );
+		}
+	} else {
+		websocketpp::lib::error_code err;
+		mServer.send(mHandle,
+					 msg,
+					 len,
+					 websocketpp::frame::opcode::BINARY,
+					 err);
+		if (err) {
+			if (mFailEventHandler != nullptr) {
+				mFailEventHandler(err.message());
+			}
+		} else {
+			if (mWriteEventHandler != nullptr) {
+				mWriteEventHandler();
+			}
+		}
+	}
+}
+
 void WebSocketServer::write( const std::string& msg )
 {
 	if ( msg.empty() ) {

--- a/src/WebSocketServer.h
+++ b/src/WebSocketServer.h
@@ -56,7 +56,8 @@ public:
 	void			poll();
 	void			run();
 	void			write( const std::string& msg );
-	
+	void			write( void const * msg, size_t len );
+
 	Server&			getServer();
 	const Server&	getServer() const;
 protected:


### PR DESCRIPTION
with a method signature that matches cinder::Serial::writeBytes. uses similar error checking/reporting as the string version.
